### PR TITLE
Use firefox native click behavior

### DIFF
--- a/src/modes/hints/background/index.js
+++ b/src/modes/hints/background/index.js
@@ -5,8 +5,12 @@ import { generateHintStrings } from './hintStrings'
 let hintChars = 'adsfghjkl;'
 let autoActivateHint = false
 
+const firefoxNoNativeClick =
+  SAKA_PLATFORM === 'firefox' &&
+  navigator.userAgent.match(/\bFirefox\/(\d+)/)[1] < 96
+
 export default {
-  onOptionsChange: options => {
+  onOptionsChange: (options) => {
     hintChars = options.hintChars.length >= 2 ? options.hintChars : 'bad'
     autoActivateHint = options.autoActivateHint
   },
@@ -51,56 +55,56 @@ export default {
         }
       } catch (e) {}
     },
-    openLinkInIncognitoWindow: url => {
+    openLinkInIncognitoWindow: (url) => {
       // TODO: consider more robust URL verification like Vimium's
       browser.windows.create({ url, incognito: true })
     },
     // Needed to activate links on firefox because it ignores keyboard modifiers
-    // or doesn't execute default behaviors on click events
-    ...(SAKA_PLATFORM === 'chrome'
-      ? {}
-      : {
-        openLinkInBackgroundTab: url => {
+    // or doesn't execute default behaviors on click events (in versions < 96)
+    ...(firefoxNoNativeClick
+      ? {
+        openLinkInBackgroundTab: (url) => {
           const arg = {
             url: url,
             active: false
           }
           browser.tabs
             .query({ currentWindow: true, active: true })
-            .then(t => {
+            .then((t) => {
               arg.cookieStoreId = t[0].cookieStoreId
             })
             .finally(() => {
               browser.tabs.create(arg)
             })
         },
-        openLinkInForegroundTab: url => {
+        openLinkInForegroundTab: (url) => {
           const arg = {
             url: url,
             active: true
           }
           browser.tabs
             .query({ currentWindow: true, active: true })
-            .then(t => {
+            .then((t) => {
               arg.cookieStoreId = t[0].cookieStoreId
             })
             .finally(() => {
               browser.tabs.create(arg)
             })
         },
-        openLinkInNewWindow: url => {
+        openLinkInNewWindow: (url) => {
           const arg = {
             url: url
           }
           browser.tabs
             .query({ currentWindow: true, active: true })
-            .then(t => {
+            .then((t) => {
               arg.cookieStoreId = t[0].cookieStoreId
             })
             .finally(() => {
               browser.windows.create(arg)
             })
         }
-      })
+      }
+      : {})
   }
 }

--- a/src/modes/hints/client/activate.js
+++ b/src/modes/hints/client/activate.js
@@ -23,10 +23,14 @@ export function activate (event, target) {
  * is selected using hints mode.
  * @type {{ [key: string]: (event: KeyboardEvent, target: HTMLElement) => string }}
  */
+const firefoxNoNativeClick =
+  SAKA_PLATFORM === 'firefox' &&
+  navigator.userAgent.match(/\bFirefox\/(\d+)/)[1] < 96
+
 const activators = {
   openLink: (event, target) => {
     if (
-      SAKA_PLATFORM === 'firefox' &&
+      firefoxNoNativeClick &&
       target.nodeName === 'A' &&
       target.target === '_blank'
     ) {
@@ -40,7 +44,7 @@ const activators = {
   },
   openLinkInBackgroundTab: (event, target) => {
     mouseEvent(target, 'click', { ctrlKey: !isMac, metaKey: isMac })
-    if (SAKA_PLATFORM === 'firefox') {
+    if (firefoxNoNativeClick) {
       backgroundOpenLink('openLinkInBackgroundTab', target)
     }
     target.focus()
@@ -52,7 +56,7 @@ const activators = {
       metaKey: isMac,
       shiftKey: true
     })
-    if (SAKA_PLATFORM === 'firefox') {
+    if (firefoxNoNativeClick) {
       backgroundOpenLink('openLinkInForegroundTab', target)
     }
     target.focus()
@@ -60,7 +64,7 @@ const activators = {
   },
   openLinkInNewWindow: (event, target) => {
     mouseEvent(target, 'click', { shiftKey: true })
-    if (SAKA_PLATFORM === 'firefox') {
+    if (firefoxNoNativeClick) {
       backgroundOpenLink('openLinkInNewWindow', target)
     }
     target.focus()


### PR DESCRIPTION
I was testing out https://github.com/lusakasa/saka-key/pull/337, but noticed that it broke the normal clicking. So I did a bit of snooping.

I'm just looking at all this code for the first time so could be entirely off-base, but seems like the click event should still be passed through to use Firefox's native click behavior. Then, the other work-arounds to manually implement click behavior can be conditioned upon the firefox version.

Borrowed version-checking code from https://github.com/lusakasa/saka-key/pull/337. The `firefoxNoNativeClick` const is duplicated between files which is clearly distasteful. Suggestions welcomed.

As far as I can tell on my machine (Ubuntu 20.04 and Firefox 96), things in are now working quite smoothly. Although, I'd be surprised if I'm not glossing over any nuances.

Happy to PR to parent repo if desired.